### PR TITLE
Add base URL helper for Firebase auth domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repo Instructions for Codex Agents
+
+- Run `CI=true npm test --silent` after making changes and include the output in the PR description.
+- Summarize code changes in the PR body with bullet points under a **Summary** section.
+- Document test results under a **Testing** section in the PR body.
+- Keep commit messages concise but descriptive.

--- a/CLEANUP_CHECKLIST.md
+++ b/CLEANUP_CHECKLIST.md
@@ -1,0 +1,30 @@
+# Code Cleanup Checklist
+
+下列檔案與函式目前在專案中未被使用或可能重複，可考慮逐步移除或重構：
+
+## Unused Components / Assets
+- [ ] `src/components/ScoreCard.tsx` - component not referenced by any page
+- [ ] `nicetone.webp` (repo root) - only referenced in README
+- [ ] `debug-horizontal-scroll.js` - debug script not imported anywhere
+- [ ] `quick-debug.js` - debug script not imported anywhere
+
+## Unused Utility Functions
+- [ ] `generateSpeech` (src/utils/api.ts)
+- [ ] `generateSpeechStream` (src/utils/api.ts)
+- [ ] `getVoiceById` (src/config/voiceConfig.ts)
+- [ ] `getVoicesByGender` (src/config/voiceConfig.ts)
+- [ ] `getVoiceIds` (src/config/voiceConfig.ts)
+- [ ] `isValidVoice` (src/config/voiceConfig.ts)
+- [ ] `getVoiceListString` (src/config/voiceConfig.ts)
+
+## Unused Storage Helpers
+- [ ] `getTextareaHeight` (src/utils/storage.ts)
+- [ ] `saveTextareaHeight` (src/utils/storage.ts)
+- [ ] `saveStrictMode` (src/utils/storage.ts)
+- [ ] `saveHistoryRecords` (src/utils/storage.ts)
+- [ ] `isValidURL` (src/utils/storage.ts)
+- [ ] `getTTSCache` (src/utils/storage.ts)
+- [ ] `getTTSCacheItem` (src/utils/storage.ts)
+- [ ] `addTTSCacheItem` (src/utils/storage.ts)
+
+依照上述清單逐項檢查並刪除或整合程式碼，可使專案更加精簡易維護。

--- a/README.md
+++ b/README.md
@@ -68,12 +68,23 @@ yarn install
    - 取得 API 金鑰和區域資訊
    - 在應用程式中設定 Azure 設定
 
-4. **啟動開發伺服器**
+4. **設定 Firebase 並啟用 Google 登入**
+   - 建立 Firebase 專案並在驗證頁啟用 Google Sign-In
+   - 在 `.env` 檔案加入下列設定：
+     ```
+      REACT_APP_FIREBASE_API_KEY=yourKey
+      # authDomain 預設會使用當前網域，可視需要覆蓋
+      REACT_APP_FIREBASE_AUTH_DOMAIN=yourApp.firebaseapp.com
+      REACT_APP_FIREBASE_PROJECT_ID=yourProjectId
+      REACT_APP_FIREBASE_APP_ID=yourAppId
+     ```
+
+5. **啟動開發伺服器**
 ```bash
 npm start
 ```
 
-5. **存取應用程式**
+6. **存取應用程式**
    - 開啟瀏覽器前往 `http://localhost:3000`
 
 ## 🛠️ 技術架構

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ yarn install
    - 在 `.env` 檔案加入下列設定：
      ```
      REACT_APP_FIREBASE_API_KEY=yourKey
-      # authDomain 預設會使用當前網域 (window.location.origin)，可視需要覆蓋
+      # authDomain 預設會使用當前網域 (window.location.hostname)，可視需要覆蓋
       REACT_APP_FIREBASE_AUTH_DOMAIN=yourApp.firebaseapp.com
       REACT_APP_FIREBASE_PROJECT_ID=yourProjectId
       REACT_APP_FIREBASE_APP_ID=yourAppId

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ yarn install
    - 建立 Firebase 專案並在驗證頁啟用 Google Sign-In
    - 在 `.env` 檔案加入下列設定：
      ```
-      REACT_APP_FIREBASE_API_KEY=yourKey
-      # authDomain 預設會使用當前網域，可視需要覆蓋
+     REACT_APP_FIREBASE_API_KEY=yourKey
+      # authDomain 預設會使用當前網域 (window.location.origin)，可視需要覆蓋
       REACT_APP_FIREBASE_AUTH_DOMAIN=yourApp.firebaseapp.com
       REACT_APP_FIREBASE_PROJECT_ID=yourProjectId
       REACT_APP_FIREBASE_APP_ID=yourAppId

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.6.0",
+    "firebase": "^9.22.2",
     "react-scripts": "5.0.1",
     "temp": "^0.9.4",
     "tesseract.js": "^5.0.4",

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import PronunciationAssessment from "./pages/PronunciationAssessment";
 import Landing from "./pages/Landing";
+import Login from "./pages/Login";
 import './App.css';
 
 function App() {
@@ -11,6 +12,7 @@ function App() {
         <Routes>
           <Route path="/" element={<PronunciationAssessment />} />
           <Route path="/intro" element={<Landing />} />
+          <Route path="/login" element={<Login />} />
         </Routes>
       </div>
     </Router>

--- a/src/components/FavoriteList.tsx
+++ b/src/components/FavoriteList.tsx
@@ -16,6 +16,7 @@ interface FavoriteListProps {
   onManageTags: () => void;
   currentText: string;
   lastAddedFavoriteId?: string | null;
+  highlightedFavoriteId?: string | null;
 }
 
 const FavoriteList: React.FC<FavoriteListProps> = ({
@@ -30,7 +31,8 @@ const FavoriteList: React.FC<FavoriteListProps> = ({
   onAddFavorite,
   onManageTags,
   currentText,
-  lastAddedFavoriteId
+  lastAddedFavoriteId,
+  highlightedFavoriteId
 }) => {
   // 數據規範化 - 確保每個收藏項目都有正確的數據結構
   const normalizedFavorites: Favorite[] = favorites.map((fav: any) => {
@@ -409,18 +411,12 @@ const FavoriteList: React.FC<FavoriteListProps> = ({
           {normalizedFavorites.length > 0 ? (
             <ul style={{ listStyle: "none", padding: 0 }}>
               {filteredFavorites.map((fav) => (
-                <li 
-                  key={fav.id} 
+                <li
+                  key={fav.id}
                   id={`favorite-item-${fav.id}`}
-                  style={{
-                    background: "rgba(44, 44, 48, 0.5)", 
-                    padding: "12px", 
-                    borderRadius: "12px", 
-                    marginBottom: "10px", 
-                    display: "flex", 
-                    flexDirection: "column",
-                    border: "1px solid var(--ios-border)"
-                  }}
+                  className={`favorite-item ${
+                    fav.id === highlightedFavoriteId ? 'favorite-selected' : ''
+                  }`}
                 >
                   <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 8 }}>
                     <span 

--- a/src/config/authDomain.ts
+++ b/src/config/authDomain.ts
@@ -1,0 +1,3 @@
+export const getAuthDomain = (): string => {
+  return window.location.hostname;
+};

--- a/src/config/baseUrl.ts
+++ b/src/config/baseUrl.ts
@@ -1,3 +1,0 @@
-export const getBaseUrl = (): string => {
-  return window.location.origin;
-};

--- a/src/config/baseUrl.ts
+++ b/src/config/baseUrl.ts
@@ -1,7 +1,3 @@
 export const getBaseUrl = (): string => {
-  const hostname = window.location.hostname;
-  if (hostname === "localhost") return "http://localhost:3000";
-  if (hostname === "preview.nicetone.dev") return "https://preview.nicetone.dev";
-  if (hostname === "nicetone.vercel.app") return "https://nicetone.vercel.app";
-  return "https://nicetone.dev";
+  return window.location.origin;
 };

--- a/src/config/baseUrl.ts
+++ b/src/config/baseUrl.ts
@@ -1,0 +1,7 @@
+export const getBaseUrl = (): string => {
+  const hostname = window.location.hostname;
+  if (hostname === "localhost") return "http://localhost:3000";
+  if (hostname === "preview.nicetone.dev") return "https://preview.nicetone.dev";
+  if (hostname === "nicetone.vercel.app") return "https://nicetone.vercel.app";
+  return "https://nicetone.dev";
+};

--- a/src/config/firebaseConfig.ts
+++ b/src/config/firebaseConfig.ts
@@ -1,0 +1,15 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth, GoogleAuthProvider } from 'firebase/auth';
+import { getBaseUrl } from './baseUrl';
+
+const firebaseConfig = {
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN || getBaseUrl(),
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+
+export const auth = getAuth(app);
+export const googleProvider = new GoogleAuthProvider();

--- a/src/config/firebaseConfig.ts
+++ b/src/config/firebaseConfig.ts
@@ -1,10 +1,10 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth, GoogleAuthProvider } from 'firebase/auth';
-import { getBaseUrl } from './baseUrl';
+import { getAuthDomain } from './authDomain';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
-  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN || getBaseUrl(),
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN || getAuthDomain(),
   projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
   appId: process.env.REACT_APP_FIREBASE_APP_ID,
 };

--- a/src/hooks/useFirebaseAuth.ts
+++ b/src/hooks/useFirebaseAuth.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { auth, googleProvider } from '../config/firebaseConfig';
+import { signInWithPopup, signOut, onAuthStateChanged, User } from 'firebase/auth';
+
+export interface AuthResult {
+  user: User | null;
+  signInWithGoogle: () => Promise<void>;
+  signOutUser: () => Promise<void>;
+}
+
+export const useFirebaseAuth = (): AuthResult => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => setUser(u));
+    return unsub;
+  }, []);
+
+  const signInWithGoogle = () => signInWithPopup(auth, googleProvider).then(() => void 0);
+  const signOutUser = () => signOut(auth);
+
+  return { user, signInWithGoogle, signOutUser };
+};

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useFirebaseAuth } from '../hooks/useFirebaseAuth';
+
+const Login: React.FC = () => {
+  const { user, signInWithGoogle, signOutUser } = useFirebaseAuth();
+
+  return (
+    <div className="login-page" style={{ padding: '2rem' }}>
+      {user ? (
+        <div>
+          <p>Welcome, {user.displayName}</p>
+          <button onClick={signOutUser}>Sign Out</button>
+        </div>
+      ) : (
+        <button onClick={signInWithGoogle}>Login with Google</button>
+      )}
+    </div>
+  );
+};
+
+export default Login;

--- a/src/styles/PronunciationAssessment.css
+++ b/src/styles/PronunciationAssessment.css
@@ -417,6 +417,12 @@
   padding: 12px;
 }
 
+/* 當前選中的收藏項目樣式 */
+.favorite-selected {
+  border-color: var(--ios-warning);
+  background: rgba(255, 159, 10, 0.15);
+}
+
 /* Tag styling */
 .tag {
   border-radius: 16px;


### PR DESCRIPTION
## Summary
- default Firebase authDomain to current site URL via `getBaseUrl`
- document optional Firebase authDomain in README

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461816b1b48329b1e89fd433f58986