### PR TITLE
Implement modal for Android webview

### DIFF
--- a/src/components/AndroidChromeModal.css
+++ b/src/components/AndroidChromeModal.css
@@ -1,0 +1,58 @@
+.android-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.android-modal {
+  background: white;
+  border-radius: 16px;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  overflow: hidden;
+}
+
+.android-modal-header {
+  padding: 20px;
+  border-bottom: 1px solid #e9ecef;
+  text-align: center;
+}
+
+.android-modal-body {
+  padding: 20px;
+  text-align: center;
+  color: #495057;
+}
+
+.android-modal-actions {
+  display: flex;
+  justify-content: center;
+  padding: 16px 20px 24px;
+  border-top: 1px solid #e9ecef;
+}
+
+.btn-primary {
+  padding: 12px 24px;
+  border: 2px solid #007bff;
+  background: #007bff;
+  color: white;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-primary:hover {
+  background: #0056b3;
+  border-color: #0056b3;
+}

--- a/src/components/AndroidChromeModal.css
+++ b/src/components/AndroidChromeModal.css
@@ -12,7 +12,7 @@
 }
 
 .android-modal {
-  background: white;
+  /* background: white; */
   border-radius: 16px;
   max-width: 400px;
   width: 90%;

--- a/src/components/AndroidChromeModal.tsx
+++ b/src/components/AndroidChromeModal.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import './AndroidChromeModal.css';
+
+interface AndroidChromeModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+}
+
+const AndroidChromeModal: React.FC<AndroidChromeModalProps> = ({ isOpen, onConfirm }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="android-modal-overlay">
+      <div className="android-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="android-modal-header">
+          <h2>切換至 Chrome 瀏覽器</h2>
+        </div>
+        <div className="android-modal-body">
+          <p>為了更加的使用體驗，將為您切換到 Chrome 瀏覽器。</p>
+        </div>
+        <div className="android-modal-actions">
+          <button className="btn-primary" onClick={onConfirm}>前往 Chrome</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AndroidChromeModal;

--- a/src/pages/PronunciationAssessment.tsx
+++ b/src/pages/PronunciationAssessment.tsx
@@ -15,6 +15,9 @@ import LoginModal from "../components/LoginModal";
 import ShareImportModal from "../components/ShareImportModal";
 import AndroidChromeModal from "../components/AndroidChromeModal";
 
+// 瀏覽器環境檢測
+import { isAndroidWebView } from "../utils/browserDetection";
+
 import { Tooltip } from 'react-tooltip';
 
 // 鉤子導入
@@ -173,6 +176,13 @@ const PronunciationAssessment: React.FC = () => {
     return () => {
       window.removeEventListener('showAndroidChromeModal', handleShowAndroidModal);
     };
+  }, []);
+
+  // 初次載入時若為 Android WebView 直接顯示 Modal
+  useEffect(() => {
+    if (isAndroidWebView()) {
+      setShowAndroidModal(true);
+    }
   }, []);
 
   // 登入後載入 Firestore 收藏並在更新時同步

--- a/src/pages/PronunciationAssessment.tsx
+++ b/src/pages/PronunciationAssessment.tsx
@@ -13,6 +13,7 @@ import ShareData from "../components/ShareData";
 import ResizableTextarea from "../components/ResizableTextarea";
 import LoginModal from "../components/LoginModal";
 import ShareImportModal from "../components/ShareImportModal";
+import AndroidChromeModal from "../components/AndroidChromeModal";
 
 import { Tooltip } from 'react-tooltip';
 
@@ -141,6 +142,9 @@ const PronunciationAssessment: React.FC = () => {
   const [shareImportData, setShareImportData] = useState<any>(null);
   const [shareImportLoading, setShareImportLoading] = useState<boolean>(false);
 
+  // Android WebView 提示 Modal 狀態
+  const [showAndroidModal, setShowAndroidModal] = useState<boolean>(false);
+
   // 監聽 iOS Facebook 操作提示事件
   useEffect(() => {
     const handleShowFacebookTooltip = () => {
@@ -155,6 +159,19 @@ const PronunciationAssessment: React.FC = () => {
 
     return () => {
       window.removeEventListener('showFacebookTooltip', handleShowFacebookTooltip);
+    };
+  }, []);
+
+  // 監聽 Android WebView 跳轉提示事件
+  useEffect(() => {
+    const handleShowAndroidModal = () => {
+      setShowAndroidModal(true);
+    };
+
+    window.addEventListener('showAndroidChromeModal', handleShowAndroidModal);
+
+    return () => {
+      window.removeEventListener('showAndroidChromeModal', handleShowAndroidModal);
     };
   }, []);
 
@@ -1213,6 +1230,12 @@ const PronunciationAssessment: React.FC = () => {
     window.history.replaceState({}, document.title, newUrl);
   };
 
+  // Android WebView Modal 確認處理
+  const handleAndroidModalConfirm = () => {
+    const intentUrl = `intent://${window.location.host}${window.location.pathname}${window.location.search}#Intent;scheme=https;package=com.android.chrome;end;`;
+    window.location.href = intentUrl;
+  };
+
   const handleDirectImport = async () => {
     if (!shareImportData) return;
     
@@ -1967,6 +1990,11 @@ const PronunciationAssessment: React.FC = () => {
             favorites: shareImportData.favorites || [],
             tags: shareImportData.tags || []
           } : undefined}
+        />
+
+        <AndroidChromeModal
+          isOpen={showAndroidModal}
+          onConfirm={handleAndroidModalConfirm}
         />
 
 

--- a/src/utils/browserDetection.ts
+++ b/src/utils/browserDetection.ts
@@ -58,11 +58,14 @@ export const isMessengerInAppBrowser = (): boolean => {
   return /messenger/i.test(ua);
 };
 
+// 檢測是否在 Android WebView 中
+export const isAndroidWebView = (): boolean => {
+  return /android/.test(ua) && (/wv/.test(ua) || isInAppBrowser());
+};
+
 // 顯示瀏覽器引導訊息
 export const showBrowserGuideMessage = (): void => {
-  const isAndroid = /android/.test(ua);
-
-  if (isAndroid) {
+  if (isAndroidWebView()) {
     // Android WebView 顯示跳轉提示 Modal
     console.log('Android WebView 檢測到，顯示跳轉 Chrome 的提示');
     window.dispatchEvent(new Event('showAndroidChromeModal'));

--- a/src/utils/browserDetection.ts
+++ b/src/utils/browserDetection.ts
@@ -61,13 +61,11 @@ export const isMessengerInAppBrowser = (): boolean => {
 // 顯示瀏覽器引導訊息
 export const showBrowserGuideMessage = (): void => {
   const isAndroid = /android/.test(ua);
-  
+
   if (isAndroid) {
-    // Android 直接跳轉，不顯示通知訊息
-    console.log('Android WebView 檢測到，直接跳轉到外部瀏覽器');
-    // 直接執行跳轉邏輯
-    const intentUrl = `intent://${window.location.host}${window.location.pathname}${window.location.search}#Intent;scheme=https;package=com.android.chrome;end`;
-    window.location.href = intentUrl;
+    // Android WebView 顯示跳轉提示 Modal
+    console.log('Android WebView 檢測到，顯示跳轉 Chrome 的提示');
+    window.dispatchEvent(new Event('showAndroidChromeModal'));
     return;
   }
 


### PR DESCRIPTION
## Summary
- add `AndroidChromeModal` component and styles
- dispatch modal event for Android webviews
- listen for event in `PronunciationAssessment` page
- open Chrome via intent when user confirms

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a0c2dc5988329885f33540ca0bb12