### PR TITLE
Fix auto practice wait logic

### DIFF
--- a/src/hooks/useAzureSpeech.ts
+++ b/src/hooks/useAzureSpeech.ts
@@ -58,6 +58,9 @@ interface AzureSpeechResult extends AzureSpeechState {
   ) => Promise<{ audio: HTMLAudioElement }>;
   
   cancelAzureSpeech: () => void;
+
+  // Check if the internal audio element is currently playing
+  isAudioPlaying: () => boolean;
 }
 
 export const useAzureSpeech = (): AzureSpeechResult => {
@@ -461,12 +464,19 @@ export const useAzureSpeech = (): AzureSpeechResult => {
     
     setState(prev => ({ ...prev, isLoading: false }));
   };
-  
+
+  // Expose audio playing status for external checks
+  const isAudioPlaying = () => {
+    const audio = audioRef.current;
+    return !!audio && !audio.paused && !audio.ended;
+  };
+
   return {
     ...state,
     assessWithAzure,
     speakWithAzure,
     speakWithAIServerStream,
-    cancelAzureSpeech
+    cancelAzureSpeech,
+    isAudioPlaying
   };
-}; 
+};


### PR DESCRIPTION
## Summary
- expose audio playing status from `useAzureSpeech`
- use `azureSpeech.isAudioPlaying()` to wait for playback before recording
- add a dictionary lookup button and modal in the main textarea toolbar

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e513f4ca08329bffee97836065dc1