### PR TITLE
Implement compact storage for history

### DIFF
--- a/HISTORY_COMPRESSION_GUIDE.md
+++ b/HISTORY_COMPRESSION_GUIDE.md
@@ -1,0 +1,55 @@
+# History Data Compression Guide
+
+This document explains how pronunciation history records are stored in a compact format. Use this mapping when constructing prompts for the AI so it understands the meaning of each compressed field. The stored data uses short keys to reduce localStorage and Firestore usage.
+
+## Compressed Record Structure
+```json
+{
+  "a": "id",
+  "b": "text",
+  "c": 0,
+  "d": 0,
+  "e": 0,
+  "f": 0,
+  "g": 0,
+  "h": "recognizedText",
+  "i": [ /* compressed words */ ]
+}
+```
+
+### Field Mapping
+- `a` → `id`
+- `b` → `text`
+- `c` → `scoreAccuracy`
+- `d` → `scoreFluency`
+- `e` → `scoreCompleteness`
+- `f` → `scorePronunciation`
+- `g` → `timestamp`
+- `h` → `recognizedText`
+- `i` → `words` (array of compressed words)
+
+### Compressed Word Structure
+```json
+{
+  "w": "Word",
+  "p": {
+    "a": 0, // AccuracyScore
+    "e": "ErrorType"
+  },
+  "m": [
+    { "p": "Phoneme", "a": 0 }
+  ]
+}
+```
+- `w` → `Word`
+- `p.a` → `PronunciationAssessment.AccuracyScore`
+- `p.e` → `PronunciationAssessment.ErrorType`
+- `m` → `Phonemes`
+  - inside `m`, each object has:
+    - `p` → `Phoneme`
+    - `a` → `PronunciationAssessment.AccuracyScore`
+
+## Usage Notes
+- Send the compressed format to the AI to save bandwidth.
+- Decompress fields using the above mapping when presenting the data.
+- If a word or phoneme lacks a score, the corresponding accuracy fields may be omitted.

--- a/src/pages/PronunciationAssessment.tsx
+++ b/src/pages/PronunciationAssessment.tsx
@@ -1801,9 +1801,18 @@ const PronunciationAssessment: React.FC = () => {
     };
   }, [waitingForRandomBtnPos]);
 
-  // 全域快捷鍵：numpad enter/enter 觸發隨機或停止錄音
+  // 全域快捷鍵：numpad enter/enter 觸發隨機或停止錄音（避免輸入框觸發）
   useEffect(() => {
+    const isEditableElement = (el: Element | null): boolean => {
+      if (!el) return false;
+      const tag = (el as HTMLElement).tagName.toLowerCase();
+      return tag === 'input' || tag === 'textarea' || (el as HTMLElement).isContentEditable;
+    };
     const handleKeyDown = (e: KeyboardEvent) => {
+      const activeEl = document.activeElement;
+      if (isEditableElement(e.target as Element) || isEditableElement(activeEl)) {
+        return;
+      }
       if (e.code === 'NumpadEnter' || e.code === 'Enter') {
         if (recorder.recording) {
           stopAssessment();
@@ -1816,11 +1825,16 @@ const PronunciationAssessment: React.FC = () => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [recorder.recording]);
 
-  // 全域快捷鍵：空白鍵觸發撥放聲音（非輸入狀態）
+  // 全域快捷鍵：空白鍵觸發撥放聲音（避免輸入框觸發）
   useEffect(() => {
+    const isEditableElement = (el: Element | null): boolean => {
+      if (!el) return false;
+      const tag = (el as HTMLElement).tagName.toLowerCase();
+      return tag === 'input' || tag === 'textarea' || (el as HTMLElement).isContentEditable;
+    };
     const handleKeyDown = (e: KeyboardEvent) => {
-      const tag = (e.target as HTMLElement).tagName.toLowerCase();
-      const isInput = tag === 'input' || tag === 'textarea' || (e.target as HTMLElement).isContentEditable;
+      const activeEl = document.activeElement;
+      const isInput = isEditableElement(e.target as Element) || isEditableElement(activeEl);
       if (!isInput && e.code === 'Space') {
         e.preventDefault();
         if (recorder.recording) {

--- a/src/pages/PronunciationAssessment.tsx
+++ b/src/pages/PronunciationAssessment.tsx
@@ -878,8 +878,7 @@ const PronunciationAssessment: React.FC = () => {
 
   const goToRandomSentence = async () => {
     const currentUser = userRef.current;
-    // 已移除 debug log
-    if (filteredFavorites.length === 0) {
+    if (!favoritesLoaded || filteredFavorites.length === 0) {
       return;
     }
     const randomIndex = Math.floor(Math.random() * filteredFavorites.length);
@@ -1740,9 +1739,10 @@ const PronunciationAssessment: React.FC = () => {
 
   useEffect(() => {
     if (currentFavoriteId) {
-      localStorage.setItem('currentFavoriteId', currentFavoriteId);
+      const key = getCurrentFavoriteIdKey(user);
+      localStorage.setItem(key, currentFavoriteId);
     }
-  }, [currentFavoriteId]);
+  }, [currentFavoriteId, user]);
 
   // 新增：控制拖放隨機按鈕顯示與位置
   const [waitingForRandomBtnPos, setWaitingForRandomBtnPos] = useState(false);
@@ -1816,14 +1816,14 @@ const PronunciationAssessment: React.FC = () => {
       if (e.code === 'NumpadEnter' || e.code === 'Enter') {
         if (recorder.recording) {
           stopAssessment();
-        } else {
+        } else if (favoritesLoaded) {
           goToRandomSentence();
         }
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [recorder.recording]);
+  }, [recorder.recording, favoritesLoaded]);
 
   // 全域快捷鍵：空白鍵觸發撥放聲音（避免輸入框觸發）
   useEffect(() => {

--- a/src/types/speech.ts
+++ b/src/types/speech.ts
@@ -78,6 +78,13 @@ export interface Favorite {
   createdAt: number;
 }
 
+// AI 指令收藏類型
+export interface PromptFavorite {
+  id: string;
+  prompt: string;
+  createdAt: number;
+}
+
 // 语音选项类型
 export interface VoiceOption extends SpeechSynthesisVoice {
   // 扩展浏览器标准的SpeechSynthesisVoice类型


### PR DESCRIPTION
## Summary
- export history compression helpers
- provide `getCompressedHistoryRecords`
- save compressed history to Firestore
- decompress history records when loading user profile
- document compressed field mapping
- send compressed history to AI and show AI messages correctly
- expand history limits for storage and AI requests
- prevent global key shortcuts when inputs are focused
- add AI prompt favorites for easy reuse
- fix `PromptFavorite` type import

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb793d1a48329874abb91c2399af2