### PR TITLE
Centralize Firestore sync

### DIFF
--- a/src/components/AIDataProcessor.tsx
+++ b/src/components/AIDataProcessor.tsx
@@ -213,6 +213,17 @@ const AIDataProcessor: React.FC<AIDataProcessorProps> = ({
     storage.savePromptFavorites(promptFavorites);
   }, [promptFavorites, promptFavoritesLoaded]);
 
+  // 接收集中同步事件更新指令收藏
+  useEffect(() => {
+    const handler = (e: any) => {
+      if (Array.isArray(e.detail)) {
+        setPromptFavorites(e.detail);
+      }
+    };
+    window.addEventListener('refreshPromptFavorites', handler);
+    return () => window.removeEventListener('refreshPromptFavorites', handler);
+  }, []);
+
   // 處理提示文字變更，確保始終是字符串
   const handlePromptChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;

--- a/src/components/ShareData.tsx
+++ b/src/components/ShareData.tsx
@@ -53,6 +53,16 @@ const ShareData: React.FC<ShareDataProps> = ({ tags, favorites, user, onLoginReq
   useEffect(() => {
     setShareHistory(storage.getSavedShareInfo());
   }, []);
+
+  useEffect(() => {
+    const handler = (e: any) => {
+      if (Array.isArray(e.detail)) {
+        setShareHistory(e.detail);
+      }
+    };
+    window.addEventListener('refreshShareHistory', handler);
+    return () => window.removeEventListener('refreshShareHistory', handler);
+  }, []);
   
   // 當favorites變化時，預設全選
   useEffect(() => {


### PR DESCRIPTION
## Summary
- watch user doc once and refresh favorites, tags, history, shareHistory and promptFavorites
- dispatch events so ShareData and AIDataProcessor update their local state

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a1b80e808329afae6bccbef13984